### PR TITLE
include libm configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,9 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(fcntl.h unistd.h)
 
+dnl Checks for libraries
+AC_CHECK_LIB([m],[sqrt])
+
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_C_BIGENDIAN


### PR DESCRIPTION
Hey,

since on some systems libm needs to be included it should be checked for in configure.
