### PR TITLE
Use the PKG_INSTALLDIR macro

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2013-01-19  Michael Pruett <michael@68k.org>
+
+	* libaudiofile/AIFF.cpp,
+	libaudiofile/AudioFormat.h,
+	libaudiofile/CAF.cpp,
+	libaudiofile/NeXT.cpp,
+	libaudiofile/VOC.cpp,
+	libaudiofile/WAVE.cpp,
+	libaudiofile/modules/G711.cpp,
+	libaudiofile/modules/IMA.cpp,
+	libaudiofile/modules/MSADPCM.cpp,
+	libaudiofile/modules/ModuleState.cpp,
+	test/InvalidCompressionFormat.cpp:
+	Validate compressed audio formats.
+
 2012-11-13  Michael Pruett <michael@68k.org>
 
 	* configure.ac, docs/Makefile.am:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2013-01-19  Michael Pruett <michael@68k.org>
 
+	* libaudiofile/format.cpp,
+	test/Makefile.am,
+	test/SampleFormat.cpp:
+	Fix null checks in afGetSampleFormat() and afGetVirtualSampleFormat().
+
+	Thanks to David Lassonde for pointing out this problem.
+
+2013-01-19  Michael Pruett <michael@68k.org>
+
 	* libaudiofile/AIFF.cpp,
 	libaudiofile/AudioFormat.h,
 	libaudiofile/CAF.cpp,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2012-10-13  Michael Pruett <michael@68k.org>
+
+	* test/*:
+	Use unique filenames for temporary files in tests.
+
+	Thanks to Giovanni Mascellani for pointing out this problem.
+
+	http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=687405
+
 2012-09-12  Michael Pruett <michael@68k.org>
 
 	* libaudiofile/AIFF.cpp,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2012-11-13  Michael Pruett <michael@68k.org>
+
+	* configure.ac, docs/Makefile.am:
+	Add support for building without documentation.
+
 2012-11-12  Michael Pruett <michael@68k.org>
 
 	* libaudiofile/File.cpp:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2013-01-19  Michael Pruett <michael@68k.org>
 
+	* libaudiofile/CAF.cpp,
+	libaudiofile/util.cpp:
+	Fix conversion specifications in error messages.
+
+2013-01-19  Michael Pruett <michael@68k.org>
+
 	* libaudiofile/format.cpp,
 	test/Makefile.am,
 	test/SampleFormat.cpp:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2012-11-12  Michael Pruett <michael@68k.org>
+
+	* libaudiofile/File.cpp:
+	Open files in binary mode on Windows.
+
+	Thanks to Fabrizio Gennari for proposing this change.
+
 2012-10-13  Michael Pruett <michael@68k.org>
 
 	* test/*:

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,6 @@ EXTRA_DIST = \
 	audiofile.pc.in \
 	audiofile-uninstalled.pc.in
 
-pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = audiofile.pc
 
 dist-hook: audiofile.spec

--- a/configure.ac
+++ b/configure.ac
@@ -98,8 +98,23 @@ AS_IF([test "$enable_valgrind" = "yes"],
 	)]
 )
 
-AC_PATH_PROG(A2X, a2x)
-AC_PATH_PROG(ASCIIDOC, asciidoc)
+AC_ARG_ENABLE(docs,
+	AS_HELP_STRING([--disable-docs], [disable documentation]),
+	[enable_documentation=$enableval],
+	[enable_documentation=yes])
+
+AM_CONDITIONAL(ENABLE_DOCUMENTATION, [test "$enable_documentation" = "yes"])
+
+AS_IF([test "$enable_documentation" = "yes"],
+	[AC_PATH_PROG(A2X, a2x, :)
+	AC_PATH_PROG(ASCIIDOC, asciidoc, :)
+	AS_IF([test "$A2X" = :],
+		[AC_MSG_WARN([Could not find a2x.])]
+	)
+	AS_IF([test "$ASCIIDOC" = :],
+		[AC_MSG_WARN([Could not find asciidoc.])]
+	)]
+)
 
 AC_CONFIG_FILES([
 	audiofile.spec

--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,9 @@ AS_IF([test "$enable_documentation" = "yes"],
 	)]
 )
 
+dnl Set the directory where pkgconfig files go
+PKG_INSTALLDIR
+
 AC_CONFIG_FILES([
 	audiofile.spec
 	audiofile.pc

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_DOCUMENTATION
+
 DOCS_TXT_MAN1 = \
 	sfconvert.1.txt \
 	sfinfo.1.txt
@@ -65,3 +67,5 @@ A2XFLAGS = $(ASCIIDOCFLAGS) -d manpage -f manpage
 html: $(DOCS_HTML)
 
 CLEANFILES = *.1 *.3 *.html
+
+endif

--- a/libaudiofile/AIFF.cpp
+++ b/libaudiofile/AIFF.cpp
@@ -1,6 +1,6 @@
 /*
 	Audio File Library
-	Copyright (C) 1998-2000, 2003-2004, 2010-2012, Michael Pruett <michael@68k.org>
+	Copyright (C) 1998-2000, 2003-2004, 2010-2013, Michael Pruett <michael@68k.org>
 	Copyright (C) 2000-2001, Silicon Graphics, Inc.
 
 	This library is free software; you can redistribute it and/or
@@ -381,11 +381,13 @@ status AIFFFile::parseCOMM(const Tag &type, size_t size)
 		else if (compressionID == "ulaw" || compressionID == "ULAW")
 		{
 			track->f.compressionType = AF_COMPRESSION_G711_ULAW;
+			track->f.byteOrder = _AF_BYTEORDER_NATIVE;
 			track->f.bytesPerPacket = track->f.channelCount;
 		}
 		else if (compressionID == "alaw" || compressionID == "ALAW")
 		{
 			track->f.compressionType = AF_COMPRESSION_G711_ALAW;
+			track->f.byteOrder = _AF_BYTEORDER_NATIVE;
 			track->f.bytesPerPacket = track->f.channelCount;
 		}
 		else if (compressionID == "fl32" || compressionID == "FL32")
@@ -642,14 +644,18 @@ AFfilesetup AIFFFile::completeSetup(AFfilesetup setup)
 		return AF_NULL_FILESETUP;
 	}
 
-	if (track->byteOrderSet &&
+	if (track->f.isUncompressed() &&
+		track->byteOrderSet &&
 		track->f.byteOrder != AF_BYTEORDER_BIGENDIAN &&
-		track->f.sampleWidth > 8)
+		track->f.isByteOrderSignificant())
 	{
 		_af_error(AF_BAD_BYTEORDER,
 			"AIFF/AIFF-C format supports only big-endian data");
+		return AF_NULL_FILESETUP;
 	}
-	track->f.byteOrder = AF_BYTEORDER_BIGENDIAN;
+
+	if (track->f.isUncompressed())
+		track->f.byteOrder = AF_BYTEORDER_BIGENDIAN;
 
 	if (setup->instrumentSet)
 	{

--- a/libaudiofile/AudioFormat.h
+++ b/libaudiofile/AudioFormat.h
@@ -61,6 +61,7 @@ struct AudioFormat
 	bool isCompressed() const;
 	bool isUncompressed() const;
 	bool isPacked() const { return packed; }
+	bool isByteOrderSignificant() const { return sampleWidth > 8; }
 
 	void computeBytesPerPacketPCM();
 

--- a/libaudiofile/CAF.cpp
+++ b/libaudiofile/CAF.cpp
@@ -1,6 +1,6 @@
 /*
 	Audio File Library
-	Copyright (C) 2011-2012, Michael Pruett <michael@68k.org>
+	Copyright (C) 2011-2013, Michael Pruett <michael@68k.org>
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of the GNU Library General Public
@@ -190,13 +190,6 @@ AFfilesetup CAFFile::completeSetup(AFfilesetup setup)
 			"compression format %d not supported in CAF file",
 			track->f.compressionType);
 		return AF_NULL_FILESETUP;
-	}
-
-	if (track->f.compressionType == AF_COMPRESSION_IMA)
-	{
-		track->f.sampleWidth = 16;
-		track->f.sampleFormat = AF_SAMPFMT_TWOSCOMP;
-		track->f.byteOrder = _AF_BYTEORDER_NATIVE;
 	}
 
 	if (track->markersSet && track->markerCount)

--- a/libaudiofile/CAF.cpp
+++ b/libaudiofile/CAF.cpp
@@ -107,8 +107,8 @@ status CAFFile::readInit(AFfilesetup setup)
 			chunkLength = fileLength - currentOffset;
 		else if (chunkLength < 0)
 			_af_error(AF_BAD_HEADER,
-				"invalid chunk length %lld for chunk type %s\n",
-				chunkLength, chunkType.name().c_str());
+				"invalid chunk length %jd for chunk type %s\n",
+				static_cast<intmax_t>(chunkLength), chunkType.name().c_str());
 
 		if (chunkType == "desc")
 		{

--- a/libaudiofile/File.cpp
+++ b/libaudiofile/File.cpp
@@ -81,6 +81,9 @@ File *File::open(const char *path, File::AccessMode mode)
 		flags = O_RDONLY;
 	else if (mode == WriteAccess)
 		flags = O_CREAT | O_WRONLY | O_TRUNC;
+#if defined(WIN32) || defined(__CYGWIN__)
+	flags |= O_BINARY;
+#endif
 	int fd = ::open(path, flags, 0666);
 	if (fd == -1)
 		return NULL;

--- a/libaudiofile/VOC.cpp
+++ b/libaudiofile/VOC.cpp
@@ -1,6 +1,6 @@
 /*
 	Audio File Library
-	Copyright (C) 2011, Michael Pruett <michael@68k.org>
+	Copyright (C) 2011-2013, Michael Pruett <michael@68k.org>
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of the GNU Library General Public
@@ -127,17 +127,17 @@ AFfilesetup VOCFile::completeSetup(AFfilesetup setup)
 		_af_set_sample_format(&track->f, AF_SAMPFMT_TWOSCOMP,
 			track->f.sampleWidth);
 
-	if (track->byteOrderSet && track->f.byteOrder != AF_BYTEORDER_LITTLEENDIAN)
+	if (track->f.isUncompressed() &&
+		track->byteOrderSet &&
+		track->f.byteOrder != AF_BYTEORDER_LITTLEENDIAN &&
+		track->f.isByteOrderSignificant())
 	{
-		// Treat error as correctable.
 		_af_error(AF_BAD_BYTEORDER, "VOC supports only little-endian data");
-		track->f.byteOrder = AF_BYTEORDER_LITTLEENDIAN;
+		return AF_NULL_FILESETUP;
 	}
 
-	if (track->f.compressionType == AF_COMPRESSION_NONE)
+	if (track->f.isUncompressed())
 		track->f.byteOrder = AF_BYTEORDER_LITTLEENDIAN;
-	else
-		track->f.byteOrder = _AF_BYTEORDER_NATIVE;
 
 	if (track->f.compressionType != AF_COMPRESSION_NONE &&
 		track->f.compressionType != AF_COMPRESSION_G711_ULAW &&
@@ -294,12 +294,14 @@ status VOCFile::readInit(AFfilesetup)
 			else if (format == kVOCFormatAlaw)
 			{
 				track->f.compressionType = AF_COMPRESSION_G711_ALAW;
+				track->f.byteOrder = _AF_BYTEORDER_NATIVE;
 				track->f.bytesPerPacket = track->f.channelCount;
 				_af_set_sample_format(&track->f, AF_SAMPFMT_TWOSCOMP, 16);
 			}
 			else if (format == kVOCFormatUlaw)
 			{
 				track->f.compressionType = AF_COMPRESSION_G711_ULAW;
+				track->f.byteOrder = _AF_BYTEORDER_NATIVE;
 				track->f.bytesPerPacket = track->f.channelCount;
 				_af_set_sample_format(&track->f, AF_SAMPFMT_TWOSCOMP, 16);
 			}

--- a/libaudiofile/format.cpp
+++ b/libaudiofile/format.cpp
@@ -241,10 +241,10 @@ void afGetSampleFormat (AFfilehandle file, int trackid, int *sampleFormat, int *
 	if (!track)
 		return;
 
-	if (sampleFormat != NULL)
+	if (sampleFormat)
 		*sampleFormat = track->f.sampleFormat;
 
-	if (sampleFormat != NULL)
+	if (sampleWidth)
 		*sampleWidth = track->f.sampleWidth;
 }
 
@@ -257,10 +257,10 @@ void afGetVirtualSampleFormat (AFfilehandle file, int trackid, int *sampleFormat
 	if (!track)
 		return;
 
-	if (sampleFormat != NULL)
+	if (sampleFormat)
 		*sampleFormat = track->v.sampleFormat;
 
-	if (sampleFormat != NULL)
+	if (sampleWidth)
 		*sampleWidth = track->v.sampleWidth;
 }
 

--- a/libaudiofile/modules/G711.cpp
+++ b/libaudiofile/modules/G711.cpp
@@ -1,7 +1,7 @@
 /*
 	Audio File Library
 	Copyright (C) 2000-2001, Silicon Graphics, Inc.
-	Copyright (C) 2010, Michael Pruett <michael@68k.org>
+	Copyright (C) 2010-2013, Michael Pruett <michael@68k.org>
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of the GNU Library General Public
@@ -64,18 +64,15 @@ bool _af_g711_format_ok (AudioFormat *f)
 	if (f->sampleFormat != AF_SAMPFMT_TWOSCOMP || f->sampleWidth != 16)
 	{
 		_af_error(AF_BAD_COMPRESSION,
-		       "G711 compression requires 16-bit signed integer format");
-		f->sampleFormat = AF_SAMPFMT_TWOSCOMP;
-		f->sampleWidth = 16;
-		/* non-fatal */
+		       "G.711 compression requires 16-bit signed integer format");
+		return false;
 	}
 
-	if (f->byteOrder != AF_BYTEORDER_BIGENDIAN)
+	if (f->byteOrder != _AF_BYTEORDER_NATIVE)
 	{
 		_af_error(AF_BAD_COMPRESSION,
-		       "G711 compression requires big endian format");
-		f->byteOrder = AF_BYTEORDER_BIGENDIAN;
-		/* non-fatal */
+			"G.711 compression requires native byte order");
+		return false;
 	}
 
 	return true;

--- a/libaudiofile/modules/IMA.cpp
+++ b/libaudiofile/modules/IMA.cpp
@@ -1,6 +1,6 @@
 /*
 	Audio File Library
-	Copyright (C) 2010-2012, Michael Pruett <michael@68k.org>
+	Copyright (C) 2010-2013, Michael Pruett <michael@68k.org>
 	Copyright (C) 2001, Silicon Graphics, Inc.
 
 	This library is free software; you can redistribute it and/or
@@ -363,17 +363,14 @@ bool _af_ima_adpcm_format_ok (AudioFormat *f)
 	{
 		_af_error(AF_BAD_COMPRESSION,
 			"IMA ADPCM compression requires 16-bit signed integer format");
-		f->sampleFormat = AF_SAMPFMT_TWOSCOMP;
-		f->sampleWidth = 16;
-		/* non-fatal */
+		return false;
 	}
 
 	if (f->byteOrder != _AF_BYTEORDER_NATIVE)
 	{
 		_af_error(AF_BAD_COMPRESSION,
 			"IMA ADPCM compression requires native byte order");
-		f->byteOrder = _AF_BYTEORDER_NATIVE;
-		/* non-fatal */
+		return false;
 	}
 
 	return true;

--- a/libaudiofile/modules/MSADPCM.cpp
+++ b/libaudiofile/modules/MSADPCM.cpp
@@ -1,6 +1,6 @@
 /*
 	Audio File Library
-	Copyright (C) 2010-2012, Michael Pruett <michael@68k.org>
+	Copyright (C) 2010-2013, Michael Pruett <michael@68k.org>
 	Copyright (C) 2001, Silicon Graphics, Inc.
 
 	This library is free software; you can redistribute it and/or
@@ -534,17 +534,14 @@ bool _af_ms_adpcm_format_ok (AudioFormat *f)
 	{
 		_af_error(AF_BAD_COMPRESSION,
 			"MS ADPCM compression requires 16-bit signed integer format");
-		f->sampleFormat = AF_SAMPFMT_TWOSCOMP;
-		f->sampleWidth = 16;
-		/* non-fatal */
+		return false;
 	}
 
-	if (f->byteOrder != AF_BYTEORDER_BIGENDIAN)
+	if (f->byteOrder != _AF_BYTEORDER_NATIVE)
 	{
 		_af_error(AF_BAD_COMPRESSION,
-			"MS ADPCM compression requires big endian format");
-		f->byteOrder = AF_BYTEORDER_BIGENDIAN;
-		/* non-fatal */
+			"MS ADPCM compression requires native byte order");
+		return false;
 	}
 
 	return true;

--- a/libaudiofile/modules/ModuleState.cpp
+++ b/libaudiofile/modules/ModuleState.cpp
@@ -1,7 +1,7 @@
 /*
 	Audio File Library
 	Copyright (C) 2000, Silicon Graphics, Inc.
-	Copyright (C) 2010, Michael Pruett <michael@68k.org>
+	Copyright (C) 2010-2013, Michael Pruett <michael@68k.org>
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of the GNU Library General Public
@@ -51,6 +51,10 @@ status ModuleState::initFileModule(AFfilehandle file, Track *track)
 {
 	const CompressionUnit *unit = _af_compression_unit_from_id(track->f.compressionType);
 	if (!unit)
+		return AF_FAIL;
+
+	// Validate compression format and parameters.
+	if (!unit->fmtok(&track->f))
 		return AF_FAIL;
 
 	if (file->m_seekok &&

--- a/libaudiofile/util.cpp
+++ b/libaudiofile/util.cpp
@@ -89,7 +89,7 @@ void *_af_malloc (size_t size)
 
 	if (size <= 0)
 	{
-		_af_error(AF_BAD_MALLOC, "bad memory allocation size request %d", size);
+		_af_error(AF_BAD_MALLOC, "bad memory allocation size request %zd", size);
 		return NULL;
 	}
 
@@ -102,7 +102,7 @@ void *_af_malloc (size_t size)
 
 	if (p == NULL)
 	{
-		_af_error(AF_BAD_MALLOC, "allocation of %d bytes failed", size);
+		_af_error(AF_BAD_MALLOC, "allocation of %zd bytes failed", size);
 		return NULL;
 	}
 
@@ -123,7 +123,7 @@ void *_af_realloc (void *p, size_t size)
 {
 	if (size <= 0)
 	{
-		_af_error(AF_BAD_MALLOC, "bad memory allocation size request %d", size);
+		_af_error(AF_BAD_MALLOC, "bad memory allocation size request %zd", size);
 		return NULL;
 	}
 
@@ -131,7 +131,7 @@ void *_af_realloc (void *p, size_t size)
 
 	if (p == NULL)
 	{
-		_af_error(AF_BAD_MALLOC, "allocation of %d bytes failed", size);
+		_af_error(AF_BAD_MALLOC, "allocation of %zd bytes failed", size);
 		return NULL;
 	}
 
@@ -145,7 +145,7 @@ void *_af_calloc (size_t nmemb, size_t size)
 	if (nmemb <= 0 || size <= 0)
 	{
 		_af_error(AF_BAD_MALLOC, "bad memory allocation size request "
-			"%d elements of %d bytes each", nmemb, size);
+			"%zd elements of %zd bytes each", nmemb, size);
 		return NULL;
 	}
 
@@ -153,7 +153,7 @@ void *_af_calloc (size_t nmemb, size_t size)
 
 	if (p == NULL)
 	{
-		_af_error(AF_BAD_MALLOC, "allocation of %d bytes failed",
+		_af_error(AF_BAD_MALLOC, "allocation of %zd bytes failed",
 			nmemb*size);
 		return NULL;
 	}

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -15,6 +15,7 @@ PCMData
 PCMMapping
 Pipe
 Query
+SampleFormat
 Seek
 Sign
 VirtualFile

--- a/test/ADPCM.cpp
+++ b/test/ADPCM.cpp
@@ -26,7 +26,7 @@
 #include <cstdlib>
 #include <unistd.h>
 
-static const char *kTestFileName = "/tmp/adpcm-test";
+#include "TestUtilities.h"
 
 static const int kIMABytesPerPacketQT = 34;
 static const int kIMABytesPerPacketWAVE = 256;
@@ -44,11 +44,14 @@ static const int kMSADPCMThreshold = 16;
 static void testADPCM(int fileFormat, int compressionFormat, int channelCount,
 	int bytesPerPacket, int framesPerPacket, int frameCount, int threshold)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("ADPCM", &testFileName));
+
 	AFfilesetup setup = afNewFileSetup();
 	afInitFileFormat(setup, fileFormat);
 	afInitChannels(setup, AF_DEFAULT_TRACK, channelCount);
 	afInitCompression(setup, AF_DEFAULT_TRACK, compressionFormat);
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	ASSERT_TRUE(file);
 	afFreeFileSetup(setup);
 
@@ -62,7 +65,7 @@ static void testADPCM(int fileFormat, int compressionFormat, int channelCount,
 
 	ASSERT_EQ(afCloseFile(file), 0);
 
-	file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(testFileName.c_str(), "r", AF_NULL_FILESETUP);
 	ASSERT_TRUE(file);
 	ASSERT_EQ(afGetCompression(file, AF_DEFAULT_TRACK), compressionFormat);
 	ASSERT_EQ(afGetFrameCount(file, AF_DEFAULT_TRACK), frameCount);
@@ -115,7 +118,7 @@ static void testADPCM(int fileFormat, int compressionFormat, int channelCount,
 	delete [] readData;
 	delete [] offsetReadData;
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 TEST(IMA, CAF)

--- a/test/AES.cpp
+++ b/test/AES.cpp
@@ -34,15 +34,18 @@
 #include <string.h>
 #include <unistd.h>
 
-static const char *kTestFileName = "/tmp/test.aiff";
+#include "TestUtilities.h"
 
 TEST(AES, AIFF)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("AES", &testFileName));
+
 	AFfilesetup setup = afNewFileSetup();
 	afInitFileFormat(setup, AF_FILE_AIFF);
 	afInitAESChannelDataTo(setup, AF_DEFAULT_TRACK, true);
 
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	ASSERT_TRUE(file);
 
 	afFreeFileSetup(setup);
@@ -54,7 +57,7 @@ TEST(AES, AIFF)
 
 	afCloseFile(file);
 
-	file = afOpenFile(kTestFileName, "r", NULL);
+	file = afOpenFile(testFileName.c_str(), "r", NULL);
 	ASSERT_TRUE(file);
 
 	unsigned char readAESData[24];
@@ -63,7 +66,7 @@ TEST(AES, AIFF)
 
 	afCloseFile(file);
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 int main(int argc, char **argv)

--- a/test/ChannelMatrix.cpp
+++ b/test/ChannelMatrix.cpp
@@ -29,13 +29,17 @@
 
 #include <audiofile.h>
 #include <gtest/gtest.h>
+#include <string>
 
-const char *kTestFileName = "/tmp/test.aiff";
+#include "TestUtilities.h"
 
 template <typename T>
 void testChannelMatrixReading(int sampleFormat, int sampleWidth)
 {
 	// Create test file.
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("ChannelMatrix", &testFileName));
+
 	const int channelCount = 2;
 	const int frameCount = 10;
 	const T samples[channelCount * frameCount] =
@@ -49,7 +53,7 @@ void testChannelMatrixReading(int sampleFormat, int sampleWidth)
 	afInitFileFormat(setup, AF_FILE_AIFFC);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 2);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, sampleFormat, sampleWidth);
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	afFreeFileSetup(setup);
 	EXPECT_TRUE(file);
 
@@ -60,7 +64,7 @@ void testChannelMatrixReading(int sampleFormat, int sampleWidth)
 	EXPECT_EQ(afCloseFile(file), 0);
 
 	// Open file for reading and read data using different channel matrices.
-	file = afOpenFile(kTestFileName, "r", NULL);
+	file = afOpenFile(testFileName.c_str(), "r", NULL);
 	EXPECT_TRUE(file);
 
 	EXPECT_EQ(afGetChannels(file, AF_DEFAULT_TRACK), 2);
@@ -89,7 +93,7 @@ void testChannelMatrixReading(int sampleFormat, int sampleWidth)
 
 	EXPECT_EQ(afCloseFile(file), 0);
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 TEST(ChannelMatrix, ReadInt8)
@@ -138,11 +142,14 @@ void testChannelMatrixWriting(int sampleFormat, int sampleWidth)
 	for (int c=0; c<2; c++)
 	{
 		// Create test file.
+		std::string testFileName;
+		ASSERT_TRUE(createTemporaryFile("ChannelMatrix", &testFileName));
+
 		AFfilesetup setup = afNewFileSetup();
 		afInitFileFormat(setup, AF_FILE_AIFFC);
 		afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 		afInitSampleFormat(setup, AF_DEFAULT_TRACK, sampleFormat, sampleWidth);
-		AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+		AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 		afFreeFileSetup(setup);
 		EXPECT_TRUE(file);
 
@@ -159,7 +166,7 @@ void testChannelMatrixWriting(int sampleFormat, int sampleWidth)
 		EXPECT_EQ(afCloseFile(file), 0);
 
 		// Open file for reading.
-		file = afOpenFile(kTestFileName, "r", NULL);
+		file = afOpenFile(testFileName.c_str(), "r", NULL);
 		EXPECT_TRUE(file);
 
 		EXPECT_EQ(afGetChannels(file, AF_DEFAULT_TRACK), 1);
@@ -177,7 +184,7 @@ void testChannelMatrixWriting(int sampleFormat, int sampleWidth)
 
 		EXPECT_EQ(afCloseFile(file), 0);
 
-		::unlink(kTestFileName);
+		ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 	}
 }
 

--- a/test/FloatToInt.cpp
+++ b/test/FloatToInt.cpp
@@ -29,45 +29,47 @@
 
 #include <gtest/gtest.h>
 #include <audiofile.h>
-#include <stdio.h>
+#include <limits>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string>
 #include <unistd.h>
-#include <limits>
+
+#include "TestUtilities.h"
 
 class FloatToIntTest : public testing::Test
 {
 protected:
 	virtual void SetUp()
 	{
+		ASSERT_TRUE(createTemporaryFile("FloatToInt", &m_testFileName));
 	}
 	virtual void TearDown()
 	{
-		::unlink(kTestFileName);
+		ASSERT_EQ(::unlink(m_testFileName.c_str()), 0);
 	}
 
-	static const char *kTestFileName;
-
-	static AFfilehandle createTestFile(int sampleWidth)
+	AFfilehandle createTestFile(int sampleWidth)
 	{
 		AFfilesetup setup = afNewFileSetup();
 		afInitFileFormat(setup, AF_FILE_AIFFC);
 		afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 		afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, sampleWidth);
-		AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "w", setup);
 		afSetVirtualSampleFormat(file, AF_DEFAULT_TRACK, AF_SAMPFMT_FLOAT, 32);
 		afFreeFileSetup(setup);
 		return file;
 	}
-	static AFfilehandle openTestFile(int sampleWidth)
+	AFfilehandle openTestFile(int sampleWidth)
 	{
-		AFfilehandle file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "r", AF_NULL_FILESETUP);
 		afSetVirtualSampleFormat(file, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, sampleWidth);
 		return file;
 	}
-};
 
-const char *FloatToIntTest::kTestFileName = "/tmp/test.aiff";
+private:
+	std::string m_testFileName;
+};
 
 static const int8_t kMinInt8 = std::numeric_limits<int8_t>::min();
 static const int8_t kMaxInt8 = std::numeric_limits<int8_t>::max();

--- a/test/IntToFloat.cpp
+++ b/test/IntToFloat.cpp
@@ -34,39 +34,44 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <limits>
+#include <string>
+
+#include "TestUtilities.h"
 
 class IntToFloatTest : public testing::Test
 {
 protected:
 	virtual void SetUp()
 	{
+		ASSERT_TRUE(createTemporaryFile("IntToFloat", &m_testFileName));
 	}
 	virtual void TearDown()
 	{
-		::unlink(kTestFileName);
+		ASSERT_EQ(::unlink(m_testFileName.c_str()), 0);
 	}
 
-	static const char *kTestFileName;
+	static char kTestFileName[];
 
-	static AFfilehandle createTestFile(int sampleWidth)
+	AFfilehandle createTestFile(int sampleWidth)
 	{
 		AFfilesetup setup = afNewFileSetup();
 		afInitFileFormat(setup, AF_FILE_AIFFC);
 		afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 		afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, sampleWidth);
-		AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "w", setup);
 		afFreeFileSetup(setup);
 		return file;
 	}
-	static AFfilehandle openTestFile()
+	AFfilehandle openTestFile()
 	{
-		AFfilehandle file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "r", AF_NULL_FILESETUP);
 		afSetVirtualSampleFormat(file, AF_DEFAULT_TRACK, AF_SAMPFMT_FLOAT, 32);
 		return file;
 	}
-};
 
-const char *IntToFloatTest::kTestFileName = "/tmp/test.aiff";
+private:
+	std::string m_testFileName;
+};
 
 static const int8_t kMinInt8 = std::numeric_limits<int8_t>::min();
 static const int8_t kMaxInt8 = std::numeric_limits<int8_t>::max();

--- a/test/InvalidCompressionFormat.cpp
+++ b/test/InvalidCompressionFormat.cpp
@@ -24,17 +24,22 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-static const char *kTestFileName = "/tmp/testaf";
+#include "TestUtilities.h"
 
 void runTest(int fileFormat, int compressionFormat)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("InvalidCompressionFormat", &testFileName));
+
 	AFfilesetup setup = afNewFileSetup();
 	afInitFileFormat(setup, fileFormat);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 16);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 	afInitCompression(setup, AF_DEFAULT_TRACK, compressionFormat);
-	ASSERT_TRUE(afOpenFile(kTestFileName, "w", setup) == AF_NULL_FILEHANDLE);
+	ASSERT_TRUE(afOpenFile(testFileName.c_str(), "w", setup) == AF_NULL_FILEHANDLE);
 	afFreeFileSetup(setup);
+
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 TEST(AIFF, mulaw) { runTest(AF_FILE_AIFF, AF_COMPRESSION_G711_ULAW); }

--- a/test/InvalidSampleFormat.cpp
+++ b/test/InvalidSampleFormat.cpp
@@ -33,16 +33,21 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-static const char *kTestFileName = "/tmp/testaf";
+#include "TestUtilities.h"
 
 void runTest(int fileFormat, int sampleFormat, int sampleWidth)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("InvalidSampleFormat", &testFileName));
+
 	AFfilesetup setup = afNewFileSetup();
 	afInitFileFormat(setup, fileFormat);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, sampleFormat, sampleWidth);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
-	ASSERT_TRUE(afOpenFile(kTestFileName, "w", setup) == AF_NULL_FILEHANDLE);
+	ASSERT_TRUE(afOpenFile(testFileName.c_str(), "w", setup) == AF_NULL_FILEHANDLE);
 	afFreeFileSetup(setup);
+
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 void testInt8(int fileFormat)

--- a/test/Large.cpp
+++ b/test/Large.cpp
@@ -39,19 +39,22 @@
 #include <audiofile.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string>
 
-static const char *kTestFileName = "/tmp/audiofile-test";
+#include "TestUtilities.h"
 
 void testLargeFile(int fileFormat)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("ChannelMatrix", &testFileName));
+
 	AFfilesetup setup = afNewFileSetup();
 	afInitFileFormat(setup, fileFormat);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 16);
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	afFreeFileSetup(setup);
 	ASSERT_TRUE(file) << "Could not open file for writing";
 
@@ -75,7 +78,7 @@ void testLargeFile(int fileFormat)
 		"Incorrect frame count for file";
 	afCloseFile(file);
 
-	file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(testFileName.c_str(), "r", AF_NULL_FILESETUP);
 	ASSERT_TRUE(file) << "Could not open file for reading";
 	ASSERT_EQ(afGetFrameCount(file, AF_DEFAULT_TRACK), frameCount) <<
 		"Incorrect frame count for file opened for reading";
@@ -103,7 +106,7 @@ void testLargeFile(int fileFormat)
 	}
 	delete [] data;
 	afCloseFile(file);
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 TEST(Large, AIFF)

--- a/test/Loop.cpp
+++ b/test/Loop.cpp
@@ -37,11 +37,15 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string>
 
-const char *kTestFileName = "/tmp/test.aiff";
+#include "TestUtilities.h"
 
 TEST(Loop, AIFF)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("Loop", &testFileName));
+
 	AFfilesetup setup = afNewFileSetup();
 	afInitFileFormat(setup, AF_FILE_AIFF);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
@@ -64,7 +68,7 @@ TEST(Loop, AIFF)
 	int loopIDs[] = {1, 2};
 	afInitLoopIDs(setup, AF_DEFAULT_INST, loopIDs, 2);
 
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	ASSERT_TRUE(file) << "Could not open test file for writing";
 	afFreeFileSetup(setup);
 
@@ -84,7 +88,7 @@ TEST(Loop, AIFF)
 
 	afCloseFile(file);
 
-	file = afOpenFile(kTestFileName, "r", NULL);
+	file = afOpenFile(testFileName.c_str(), "r", NULL);
 	ASSERT_TRUE(file) << "Could not open test file for reading";
 
 	ASSERT_EQ(afGetLoopIDs(file, AF_DEFAULT_INST, NULL), 2);
@@ -126,7 +130,7 @@ TEST(Loop, AIFF)
 
 	afCloseFile(file);
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 int main(int argc, char **argv)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -18,6 +18,7 @@ TESTS = \
 	PCMMapping \
 	Pipe \
 	Query \
+	SampleFormat \
 	Seek \
 	Sign \
 	VirtualFile \
@@ -104,6 +105,9 @@ Pipe_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
 Query_SOURCES = Query.cpp TestUtilities.cpp
 Query_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
+
+SampleFormat_SOURCES = SampleFormat.cpp TestUtilities.cpp
+SampleFormat_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
 Seek_SOURCES = Seek.cpp TestUtilities.cpp
 Seek_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -54,65 +54,87 @@ DEPENDENCIES = $(LIBAUDIOFILE)
 
 LIBGTEST = ../gtest/libgtest.la
 
-ADPCM_SOURCES = ADPCM.cpp
+ADPCM_SOURCES = ADPCM.cpp TestUtilities.cpp
 ADPCM_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-AES_SOURCES = AES.cpp
+AES_SOURCES = AES.cpp TestUtilities.cpp
 AES_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-ChannelMatrix_SOURCES = ChannelMatrix.cpp
+ChannelMatrix_SOURCES = ChannelMatrix.cpp TestUtilities.cpp
 ChannelMatrix_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Error_SOURCES = Error.cpp
+Error_SOURCES = Error.cpp TestUtilities.cpp
 Error_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-FloatToInt_SOURCES = FloatToInt.cpp
+FloatToInt_SOURCES = FloatToInt.cpp TestUtilities.cpp
 FloatToInt_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-IntToFloat_SOURCES = IntToFloat.cpp
+IntToFloat_SOURCES = IntToFloat.cpp TestUtilities.cpp
 IntToFloat_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-InvalidCompressionFormat_SOURCES = InvalidCompressionFormat.cpp
+InvalidCompressionFormat_SOURCES = InvalidCompressionFormat.cpp TestUtilities.cpp
 InvalidCompressionFormat_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-InvalidSampleFormat_SOURCES = InvalidSampleFormat.cpp
+InvalidSampleFormat_SOURCES = InvalidSampleFormat.cpp TestUtilities.cpp
 InvalidSampleFormat_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Large_SOURCES = Large.cpp
+Large_SOURCES = Large.cpp TestUtilities.cpp
 Large_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Loop_SOURCES = Loop.cpp
+Loop_SOURCES = Loop.cpp TestUtilities.cpp
 Loop_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Marker_SOURCES = Marker.cpp
+Marker_SOURCES = Marker.cpp TestUtilities.cpp
 Marker_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Miscellaneous_SOURCES = Miscellaneous.cpp
+Miscellaneous_SOURCES = Miscellaneous.cpp TestUtilities.cpp
 Miscellaneous_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-NeXT_SOURCES = NeXT.cpp
+NeXT_SOURCES = NeXT.cpp TestUtilities.cpp
 NeXT_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-PCMData_SOURCES = PCMData.cpp
+PCMData_SOURCES = PCMData.cpp TestUtilities.cpp
 PCMData_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-PCMMapping_SOURCES = PCMMapping.cpp
+PCMMapping_SOURCES = PCMMapping.cpp TestUtilities.cpp
 PCMMapping_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Pipe_SOURCES = Pipe.cpp
+Pipe_SOURCES = Pipe.cpp TestUtilities.cpp
 Pipe_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Query_SOURCES = Query.cpp
+Query_SOURCES = Query.cpp TestUtilities.cpp
 Query_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Seek_SOURCES = Seek.cpp
+Seek_SOURCES = Seek.cpp TestUtilities.cpp
 Seek_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-Sign_SOURCES = Sign.cpp
+Sign_SOURCES = Sign.cpp TestUtilities.cpp
 Sign_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
 
-VirtualFile_SOURCES = VirtualFile.cpp
+VirtualFile_SOURCES = VirtualFile.cpp TestUtilities.cpp
 VirtualFile_LDADD = $(LIBGTEST) $(LIBAUDIOFILE)
+
+floatto24_SOURCES = floatto24.c TestUtilities.cpp
 
 printmarkers_SOURCES = printmarkers.c
 printmarkers_LDADD = $(LIBAUDIOFILE) -lm
+
+sixteen_to_eight_SOURCES = sixteen-to-eight.c TestUtilities.cpp
+
+testchannelmatrix_SOURCES = testchannelmatrix.c TestUtilities.cpp
+
+testdouble_SOURCES = testdouble.c TestUtilities.cpp
+
+testfloat_SOURCES = testfloat.c TestUtilities.cpp
+
+testmarkers_SOURCES = testmarkers.c TestUtilities.cpp
+
+twentyfour_SOURCES = twentyfour.c TestUtilities.cpp
+
+twentyfour2_SOURCES = twentyfour2.c TestUtilities.cpp
+
+writealaw_SOURCES = writealaw.c TestUtilities.cpp
+
+writeraw_SOURCES = writeraw.c TestUtilities.cpp
+
+writeulaw_SOURCES = writeulaw.c TestUtilities.cpp

--- a/test/Miscellaneous.cpp
+++ b/test/Miscellaneous.cpp
@@ -35,6 +35,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "TestUtilities.h"
+
 struct Miscellaneous
 {
 	int id;
@@ -50,9 +52,7 @@ const Miscellaneous kMiscellaneous[] =
 
 const int kNumMiscellaneous = sizeof (kMiscellaneous) / sizeof (Miscellaneous);
 
-const char kTestFileName[] = "/tmp/test";
-
-void writeMiscellaneous(int fileFormat)
+void writeMiscellaneous(int fileFormat, const std::string &testFileName)
 {
 	AFfilesetup setup = afNewFileSetup();
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
@@ -68,7 +68,7 @@ void writeMiscellaneous(int fileFormat)
 		afInitMiscSize(setup, kMiscellaneous[i].id, strlen(kMiscellaneous[i].data));
 	}
 
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	ASSERT_TRUE(file);
 	afFreeFileSetup(setup);
 	int result;
@@ -85,9 +85,9 @@ void writeMiscellaneous(int fileFormat)
 	afCloseFile(file);
 }
 
-void readMiscellaneous()
+void readMiscellaneous(const std::string &testFileName)
 {
-	AFfilehandle file = afOpenFile(kTestFileName, "r", NULL);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "r", NULL);
 	ASSERT_TRUE(file);
 	int count = afGetMiscIDs(file, NULL);
 	EXPECT_EQ(count, kNumMiscellaneous);
@@ -115,30 +115,38 @@ void readMiscellaneous()
 
 TEST(Miscellaneous, AIFF)
 {
-	writeMiscellaneous(AF_FILE_AIFF);
-	readMiscellaneous();
-	::unlink(kTestFileName);
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("Miscellaneous", &testFileName));
+	writeMiscellaneous(AF_FILE_AIFF, testFileName);
+	readMiscellaneous(testFileName);
+	::unlink(testFileName.c_str());
 }
 
 TEST(Miscellaneous, AIFFC)
 {
-	writeMiscellaneous(AF_FILE_AIFFC);
-	readMiscellaneous();
-	::unlink(kTestFileName);
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("Miscellaneous", &testFileName));
+	writeMiscellaneous(AF_FILE_AIFFC, testFileName);
+	readMiscellaneous(testFileName);
+	::unlink(testFileName.c_str());
 }
 
 TEST(Miscellaneous, WAVE)
 {
-	writeMiscellaneous(AF_FILE_WAVE);
-	readMiscellaneous();
-	::unlink(kTestFileName);
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("Miscellaneous", &testFileName));
+	writeMiscellaneous(AF_FILE_WAVE, testFileName);
+	readMiscellaneous(testFileName);
+	::unlink(testFileName.c_str());
 }
 
 TEST(Miscellaneous, IFF_8SVX)
 {
-	writeMiscellaneous(AF_FILE_IFF_8SVX);
-	readMiscellaneous();
-	::unlink(kTestFileName);
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("Miscellaneous", &testFileName));
+	writeMiscellaneous(AF_FILE_IFF_8SVX, testFileName);
+	readMiscellaneous(testFileName);
+	::unlink(testFileName.c_str());
 }
 
 int main(int argc, char **argv)

--- a/test/NeXT.cpp
+++ b/test/NeXT.cpp
@@ -33,6 +33,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string>
+
+#include "TestUtilities.h"
 
 const char kDataUnspecifiedLength[] =
 {
@@ -77,16 +80,17 @@ const char kDataTruncated[] =
 const int16_t kFrames[] = { 1, 1, 2, 3, 5, 8, 13, 21, 34, 55 };
 const int kFrameCount = sizeof (kFrames) / sizeof (kFrames[0]);
 
-const char *kTestFileName = "/tmp/test.au";
-
 TEST(NeXT, UnspecifiedLength)
 {
-	int fd = ::open(kTestFileName, O_RDWR | O_CREAT | O_TRUNC, 0644);
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("NeXT", &testFileName));
+
+	int fd = ::open(testFileName.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
 	ASSERT_GT(fd, -1);
 	ASSERT_EQ(::write(fd, kDataUnspecifiedLength, sizeof (kDataUnspecifiedLength)), sizeof (kDataUnspecifiedLength));
 	::close(fd);
 
-	AFfilehandle file = afOpenFile(kTestFileName, "r", NULL);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "r", NULL);
 	EXPECT_TRUE(file);
 
 	int sampleFormat, sampleWidth;
@@ -108,19 +112,22 @@ TEST(NeXT, UnspecifiedLength)
 
 	afCloseFile(file);
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 TEST(NeXT, Truncated)
 {
-	int fd = ::open(kTestFileName, O_RDWR | O_CREAT | O_TRUNC, 0644);
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("NeXT", &testFileName));
+
+	int fd = ::open(testFileName.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
 	ASSERT_GT(fd, -1);
 	const size_t truncatedSize = sizeof (kDataTruncated) - 4;
 	const int truncatedFrameCount = kFrameCount - 2;
 	ASSERT_EQ(::write(fd, kDataTruncated, truncatedSize), truncatedSize);
 	::close(fd);
 
-	AFfilehandle file = afOpenFile(kTestFileName, "r", NULL);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "r", NULL);
 	EXPECT_TRUE(file);
 
 	int sampleFormat, sampleWidth;
@@ -142,7 +149,7 @@ TEST(NeXT, Truncated)
 
 	afCloseFile(file);
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 int main(int argc, char **argv)

--- a/test/PCMData.cpp
+++ b/test/PCMData.cpp
@@ -33,18 +33,21 @@
 */
 
 #include <audiofile.h>
+#include <climits>
 #include <gtest/gtest.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <string>
 #include <unistd.h>
-#include <climits>
 
-static const char *kTestFileName = "/tmp/testaf";
+#include "TestUtilities.h"
 
 template <typename T, int kSampleFormat, int kBitsPerSample>
 void runTest(int fileFormat)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("PCMData", &testFileName));
+
 	T samples[] =
 	{
 		2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47,
@@ -57,7 +60,7 @@ void runTest(int fileFormat)
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, kSampleFormat, kBitsPerSample);
 
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	ASSERT_TRUE(file) << "Could not open file for writing";
 
 	afFreeFileSetup(setup);
@@ -68,7 +71,7 @@ void runTest(int fileFormat)
 
 	ASSERT_EQ(afCloseFile(file), 0) << "Error closing file";
 
-	file = afOpenFile(kTestFileName, "r", NULL);
+	file = afOpenFile(testFileName.c_str(), "r", NULL);
 	ASSERT_TRUE(file) << "Could not open file for reading";
 
 	ASSERT_EQ(afGetFileFormat(file, NULL), fileFormat) <<
@@ -95,7 +98,7 @@ void runTest(int fileFormat)
 
 	ASSERT_EQ(afCloseFile(file), 0) << "Error closing file";
 
-	::unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 void testInt8(int fileFormat)

--- a/test/PCMMapping.cpp
+++ b/test/PCMMapping.cpp
@@ -33,37 +33,39 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include "TestUtilities.h"
+
 class PCMMappingTest : public testing::Test
 {
 protected:
 	virtual void SetUp()
 	{
+		ASSERT_TRUE(createTemporaryFile("PCMMapping", &m_testFileName));
 	}
 	virtual void TearDown()
 	{
-		::unlink(kTestFileName);
+		::unlink(m_testFileName.c_str());
 	}
 
-	static const char *kTestFileName;
-
-	static AFfilehandle createTestFile(int sampleFormat, int sampleWidth)
+	AFfilehandle createTestFile(int sampleFormat, int sampleWidth)
 	{
 		AFfilesetup setup = afNewFileSetup();
 		afInitFileFormat(setup, AF_FILE_AIFFC);
 		afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 		afInitSampleFormat(setup, AF_DEFAULT_TRACK, sampleFormat, sampleWidth);
-		AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "w", setup);
 		afFreeFileSetup(setup);
 		return file;
 	}
-	static AFfilehandle openTestFile()
+	AFfilehandle openTestFile()
 	{
-		AFfilehandle file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "r", AF_NULL_FILESETUP);
 		return file;
 	}
-};
 
-const char *PCMMappingTest::kTestFileName = "/tmp/test.aiff";
+private:
+	std::string m_testFileName;
+};
 
 TEST_F(PCMMappingTest, Float)
 {

--- a/test/SampleFormat.cpp
+++ b/test/SampleFormat.cpp
@@ -1,0 +1,81 @@
+/*
+	Audio File Library
+	Copyright (C) 2013, Michael Pruett <michael@68k.org>
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License as
+	published by the Free Software Foundation; either version 2 of
+	the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be
+	useful, but WITHOUT ANY WARRANTY; without even the implied
+	warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+	PURPOSE.  See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public
+	License along with this program; if not, write to the Free
+	Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+	MA 02111-1307, USA.
+*/
+
+#include <audiofile.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "TestUtilities.h"
+
+TEST(SampleFormat, NullArguments)
+{
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("SampleFormat", &testFileName));
+
+	AFfilesetup setup = afNewFileSetup();
+	afInitFileFormat(setup, AF_FILE_AIFFC);
+	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 16);
+	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
+
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
+	ASSERT_TRUE(file);
+	afFreeFileSetup(setup);
+
+	int sampleFormat, sampleWidth;
+	afGetSampleFormat(file, AF_DEFAULT_TRACK, &sampleFormat, &sampleWidth);
+	ASSERT_EQ(sampleFormat, AF_SAMPFMT_TWOSCOMP);
+	ASSERT_EQ(sampleWidth, 16);
+
+	sampleFormat = -1;
+	afGetSampleFormat(file, AF_DEFAULT_TRACK, NULL, &sampleWidth);
+	ASSERT_EQ(sampleFormat, -1);
+	ASSERT_EQ(sampleWidth, 16);
+
+	sampleWidth = -1;
+	afGetSampleFormat(file, AF_DEFAULT_TRACK, &sampleFormat, NULL);
+	ASSERT_EQ(sampleFormat, AF_SAMPFMT_TWOSCOMP);
+	ASSERT_EQ(sampleWidth, -1);
+
+	afGetVirtualSampleFormat(file, AF_DEFAULT_TRACK, &sampleFormat, &sampleWidth);
+	ASSERT_EQ(sampleFormat, AF_SAMPFMT_TWOSCOMP);
+	ASSERT_EQ(sampleWidth, 16);
+
+	sampleFormat = -1;
+	afGetVirtualSampleFormat(file, AF_DEFAULT_TRACK, NULL, &sampleWidth);
+	ASSERT_EQ(sampleFormat, -1);
+	ASSERT_EQ(sampleWidth, 16);
+
+	sampleWidth = -1;
+	afGetVirtualSampleFormat(file, AF_DEFAULT_TRACK, &sampleFormat, NULL);
+	ASSERT_EQ(sampleFormat, AF_SAMPFMT_TWOSCOMP);
+	ASSERT_EQ(sampleWidth, -1);
+
+	ASSERT_EQ(afCloseFile(file), 0);
+
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
+}
+
+int main(int argc, char **argv)
+{
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/test/Seek.cpp
+++ b/test/Seek.cpp
@@ -31,16 +31,19 @@
 	This program tests seeking within an audio file.
 */
 
+#include <audiofile.h>
+#include <gtest/gtest.h>
 #include <stdlib.h>
+#include <string>
 #include <unistd.h>
 
-#include <gtest/gtest.h>
-#include <audiofile.h>
-
-static const char *kTestFileName = "/tmp/test.aiff";
+#include "TestUtilities.h"
 
 TEST(Seek, Seek)
 {
+	std::string testFileName;
+	ASSERT_TRUE(createTemporaryFile("Seek", &testFileName));
+
 	const int kFrameCount = 2000;
 	const int kPadFrameCount = kFrameCount + 5;
 	const int kDataLength = kFrameCount * sizeof (int16_t);
@@ -54,7 +57,7 @@ TEST(Seek, Seek)
 	afInitFileFormat(setup, AF_FILE_AIFF);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 
-	AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+	AFfilehandle file = afOpenFile(testFileName.c_str(), "w", setup);
 	ASSERT_TRUE(file) << "could not open file for writing";
 
 	afFreeFileSetup(setup);
@@ -73,7 +76,7 @@ TEST(Seek, Seek)
 
 	afCloseFile(file);
 
-	file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(testFileName.c_str(), "r", AF_NULL_FILESETUP);
 	ASSERT_TRUE(file) << "Could not open file for reading";
 
 	/*
@@ -100,7 +103,7 @@ TEST(Seek, Seek)
 
 	afCloseFile(file);
 
-	unlink(kTestFileName);
+	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
 int main (int argc, char **argv)

--- a/test/Sign.cpp
+++ b/test/Sign.cpp
@@ -27,46 +27,48 @@
 	THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <gtest/gtest.h>
 #include <audiofile.h>
-#include <stdio.h>
+#include <gtest/gtest.h>
+#include <limits>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string>
 #include <unistd.h>
-#include <limits>
+
+#include "TestUtilities.h"
 
 class SignConversionTest : public testing::Test
 {
 protected:
 	virtual void SetUp()
 	{
+		ASSERT_TRUE(createTemporaryFile("Sign", &m_testFileName));
 	}
 	virtual void TearDown()
 	{
-		::unlink(kTestFileName);
+		ASSERT_EQ(::unlink(m_testFileName.c_str()), 0);
 	}
 
-	static const char *kTestFileName;
-
-	static AFfilehandle createTestFile(int sampleWidth)
+	AFfilehandle createTestFile(int sampleWidth)
 	{
 		AFfilesetup setup = afNewFileSetup();
 		afInitFileFormat(setup, AF_FILE_AIFFC);
 		afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 		afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, sampleWidth);
-		AFfilehandle file = afOpenFile(kTestFileName, "w", setup);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "w", setup);
 		afFreeFileSetup(setup);
 		return file;
 	}
-	static AFfilehandle openTestFile(int sampleWidth)
+	AFfilehandle openTestFile(int sampleWidth)
 	{
-		AFfilehandle file = afOpenFile(kTestFileName, "r", AF_NULL_FILESETUP);
+		AFfilehandle file = afOpenFile(m_testFileName.c_str(), "r", AF_NULL_FILESETUP);
 		afSetVirtualSampleFormat(file, AF_DEFAULT_TRACK, AF_SAMPFMT_UNSIGNED, sampleWidth);
 		return file;
 	}
-};
 
-const char *SignConversionTest::kTestFileName = "/tmp/test.aiff";
+private:
+	std::string m_testFileName;
+};
 
 static const int8_t kMinInt8 = std::numeric_limits<int8_t>::min();
 static const int8_t kMaxInt8 = std::numeric_limits<int8_t>::max();

--- a/test/TestUtilities.cpp
+++ b/test/TestUtilities.cpp
@@ -1,0 +1,45 @@
+/*
+	Audio File Library
+	Copyright (C) 2012, Michael Pruett <michael@68k.org>
+
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Library General Public
+	License as published by the Free Software Foundation; either
+	version 2 of the License, or (at your option) any later version.
+
+	This library is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Library General Public License for more details.
+
+	You should have received a copy of the GNU Library General Public
+	License along with this library; if not, write to the
+	Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+	Boston, MA  02111-1307  USA.
+*/
+
+#include "TestUtilities.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+bool createTemporaryFile(const std::string &prefix, std::string *path)
+{
+	*path = "/tmp/" + prefix + "-XXXXXX";
+	int fd = ::mkstemp(const_cast<char *>(path->c_str()));
+	if (fd < 0)
+		return false;
+	::close(fd);
+	return true;
+}
+
+bool createTemporaryFile(const char *prefix, char *path)
+{
+	snprintf(path, PATH_MAX, "/tmp/%s-XXXXXX", prefix);
+	int fd = ::mkstemp(path);
+	if (fd < 0)
+		return false;
+	::close(fd);
+	return true;
+}

--- a/test/TestUtilities.h
+++ b/test/TestUtilities.h
@@ -1,0 +1,44 @@
+/*
+	Audio File Library
+	Copyright (C) 2012, Michael Pruett <michael@68k.org>
+
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Library General Public
+	License as published by the Free Software Foundation; either
+	version 2 of the License, or (at your option) any later version.
+
+	This library is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Library General Public License for more details.
+
+	You should have received a copy of the GNU Library General Public
+	License along with this library; if not, write to the
+	Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+	Boston, MA  02111-1307  USA.
+*/
+
+#ifndef TEST_UTILITIES_H
+#define TEST_UTILITIES_H
+
+#ifdef __cplusplus
+
+#include <string>
+
+bool createTemporaryFile(const std::string &prefix, std::string *path);
+
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+bool createTemporaryFile(const char *prefix, char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/test/floatto24.c
+++ b/test/floatto24.c
@@ -36,8 +36,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
+#include <limits.h>
 
-#define TEST_FILE "/tmp/test.sf"
+#include "TestUtilities.h"
 
 /*
 	When converted to samples with width 24 bits, the samples
@@ -85,7 +87,14 @@ int main (int argc, char **argv)
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_FLOAT, 32);
 
-	AFfilehandle file = afOpenFile(TEST_FILE, "w", setup);
+	char testFileName[PATH_MAX];
+	if (!createTemporaryFile("floatto24", testFileName))
+	{
+		fprintf(stderr, "Could not create temporary file.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	AFfilehandle file = afOpenFile(testFileName, "w", setup);
 	if (file == AF_NULL_FILEHANDLE)
 	{
 		printf("could not open file for writing\n");
@@ -109,7 +118,7 @@ int main (int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(testFileName, "r", AF_NULL_FILESETUP);
 	if (file == AF_NULL_FILEHANDLE)
 	{
 		fprintf(stderr, "Could not open file for writing.\n");
@@ -173,7 +182,7 @@ int main (int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	unlink(TEST_FILE);
+	unlink(testFileName);
 
 	exit(EXIT_SUCCESS);
 }

--- a/test/sixteen-to-eight.c
+++ b/test/sixteen-to-eight.c
@@ -35,10 +35,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
 
 #include <audiofile.h>
-
-#define TEST_FILE "/tmp/test.wave"
 
 int main (int argc, char **argv)
 {
@@ -57,7 +56,14 @@ int main (int argc, char **argv)
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_UNSIGNED, 8);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	char testFileName[PATH_MAX];
+	if (!createTemporaryFile("sixteen-to-eight", testFileName))
+	{
+		fprintf(stderr, "Could not create temporary file.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	file = afOpenFile(testFileName, "w", setup);
 	if (file == AF_NULL_FILEHANDLE)
 	{
 		fprintf(stderr, "could not open file for writing\n");
@@ -72,7 +78,7 @@ int main (int argc, char **argv)
 
 	afCloseFile(file);
 
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(testFileName, "r", AF_NULL_FILESETUP);
 	if (file == AF_NULL_FILEHANDLE)
 	{
 		fprintf(stderr, "could not open file for reading\n");
@@ -105,7 +111,7 @@ int main (int argc, char **argv)
 	}
 
 	afCloseFile(file);
-	unlink(TEST_FILE);
+	unlink(testFileName);
 
 	exit(EXIT_SUCCESS);
 }

--- a/test/testchannelmatrix.c
+++ b/test/testchannelmatrix.c
@@ -30,6 +30,7 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,7 +38,9 @@
 
 #include <audiofile.h>
 
-#define TEST_FILE "/tmp/test.aiff"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
 
 const short samples[] = {300, -300, 515, -515, 2315, -2315, 9154, -9154};
 #define SAMPLE_COUNT (sizeof (samples) / sizeof (short))
@@ -45,7 +48,7 @@ const short samples[] = {300, -300, 515, -515, 2315, -2315, 9154, -9154};
 
 void cleanup (void)
 {
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 }
 
 void ensure (int condition, const char *message)
@@ -74,7 +77,9 @@ int main (void)
 	afInitFileFormat(setup, AF_FILE_AIFFC);
 
 	/* Write stereo data to test file. */
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("testchannelmatrix", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	ensure(file != AF_NULL_FILEHANDLE, "could not open file for writing");
 
 	afFreeFileSetup(setup);
@@ -95,7 +100,7 @@ int main (void)
 		corresponding even sample, the data read should be all
 		zeros.
 	*/
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(sTestFileName, "r", AF_NULL_FILESETUP);
 	ensure(file != AF_NULL_FILEHANDLE, "could not open file for reading");
 
 	ensure(afGetChannels(file, AF_DEFAULT_TRACK) == 2,

--- a/test/testdouble.c
+++ b/test/testdouble.c
@@ -30,13 +30,16 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #include <audiofile.h>
 
-#define TEST_FILE "/tmp/test.double"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
 
 const double samples[] =
 	{1.0, 0.6, -0.3, 0.95, 0.2, -0.6, 0.9, 0.4, -0.22, 0.125, 0.1, -0.4};
@@ -46,7 +49,7 @@ void testdouble (int fileFormat);
 
 void cleanup (void)
 {
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 }
 
 void ensure (int condition, const char *message)
@@ -94,7 +97,9 @@ void testdouble (int fileFormat)
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_DOUBLE, 64);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 2);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("testdouble", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	ensure(file != AF_NULL_FILEHANDLE, "could not open file for writing");
 
 	afFreeFileSetup(setup);
@@ -105,7 +110,7 @@ void testdouble (int fileFormat)
 
 	ensure(afCloseFile(file) == 0, "error closing file");
 
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(sTestFileName, "r", AF_NULL_FILESETUP);
 	ensure(file != AF_NULL_FILEHANDLE, "could not open file for reading");
 
 	ensure(afGetChannels(file, AF_DEFAULT_TRACK) == 2,

--- a/test/testfloat.c
+++ b/test/testfloat.c
@@ -30,13 +30,16 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
 #include <audiofile.h>
 
-#define TEST_FILE "/tmp/test.float"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
 
 const float samples[] =
 	{1.0, 0.6, -0.3, 0.95, 0.2, -0.6, 0.9, 0.4, -0.22, 0.125, 0.1, -0.4};
@@ -46,7 +49,7 @@ void testfloat (int fileFormat);
 
 void cleanup (void)
 {
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 }
 
 void ensure (int condition, const char *message)
@@ -94,7 +97,9 @@ void testfloat (int fileFormat)
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_FLOAT, 32);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 2);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("testfloat", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	ensure(file != AF_NULL_FILEHANDLE, "could not open file for writing");
 
 	afFreeFileSetup(setup);
@@ -105,7 +110,7 @@ void testfloat (int fileFormat)
 
 	ensure(afCloseFile(file) == 0, "error closing file");
 
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(sTestFileName, "r", AF_NULL_FILESETUP);
 	ensure(file != AF_NULL_FILEHANDLE, "could not open file for reading");
 
 	ensure(afGetChannels(file, AF_DEFAULT_TRACK) == 2,

--- a/test/testmarkers.c
+++ b/test/testmarkers.c
@@ -23,6 +23,7 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,14 +31,16 @@
 
 #include <audiofile.h>
 
-#define TEST_FILE "/tmp/markers.test"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
 
 #define FRAME_COUNT 200
 
 void cleanup (void)
 {
 #ifndef DEBUG
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 #endif
 }
 
@@ -76,7 +79,7 @@ int testmarkers (int fileformat)
 	afInitMarkName(setup, AF_DEFAULT_TRACK, markids[2], marknames[2]);
 	afInitMarkName(setup, AF_DEFAULT_TRACK, markids[3], marknames[3]);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	file = afOpenFile(sTestFileName, "w", setup);
 	ensure(file != AF_NULL_FILEHANDLE, "Could not open file for writing");
 
 	afFreeFileSetup(setup);
@@ -91,7 +94,7 @@ int testmarkers (int fileformat)
 
 	afCloseFile(file);
 
-	file = afOpenFile(TEST_FILE, "r", NULL);
+	file = afOpenFile(sTestFileName, "r", NULL);
 	ensure(file != AF_NULL_FILEHANDLE, "Could not open file for reading");
 
 	readmarkcount = afGetMarkIDs(file, AF_DEFAULT_TRACK, NULL);
@@ -125,6 +128,9 @@ int testmarkers (int fileformat)
 
 int main (void)
 {
+	ensure(createTemporaryFile("testmarkers", sTestFileName),
+		"could not create temporary file");
+
 	testmarkers(AF_FILE_AIFF);
 	testmarkers(AF_FILE_AIFFC);
 	testmarkers(AF_FILE_WAVE);

--- a/test/twentyfour.c
+++ b/test/twentyfour.c
@@ -32,6 +32,7 @@
 #endif
 
 #include <assert.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +41,8 @@
 
 #include <audiofile.h>
 
-#define TEST_FILE "/tmp/test.aiff"
+#include "TestUtilities.h"
+
 #define FRAME_COUNT 6
 
 int main (int argc, char **argv)
@@ -70,7 +72,14 @@ int main (int argc, char **argv)
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 24);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	char testFileName[PATH_MAX];
+	if (!createTemporaryFile("twentyfour", testFileName))
+	{
+		fprintf(stderr, "could not create temporary file\n");
+		exit(EXIT_FAILURE);
+	}
+
+	file = afOpenFile(testFileName, "w", setup);
 	if (file == AF_NULL_FILEHANDLE)
 	{
 		fprintf(stderr, "could not open file for writing\n");
@@ -84,7 +93,7 @@ int main (int argc, char **argv)
 
 	afCloseFile(file);
 
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(testFileName, "r", AF_NULL_FILESETUP);
 	if (file == AF_NULL_FILEHANDLE)
 	{
 		fprintf(stderr, "could not open file for reading\n");
@@ -230,7 +239,7 @@ int main (int argc, char **argv)
 		fprintf(stderr, "Error closing file.\n");
 		exit(EXIT_FAILURE);
 	}
-	unlink(TEST_FILE);
+	unlink(testFileName);
 
 	exit(EXIT_SUCCESS);
 }

--- a/test/twentyfour2.c
+++ b/test/twentyfour2.c
@@ -35,6 +35,7 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,13 +44,16 @@
 
 #include <audiofile.h>
 
-#define TEST_FILE "/tmp/test.aiff"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
+
 #define FRAME_COUNT 10000
 
 void cleanup (void)
 {
 #ifndef DEBUG
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 #endif
 }
 
@@ -75,7 +79,9 @@ int main (void)
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 24);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("twentyfour2", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	ensure(file != NULL, "could not open test file for writing");
 
 	afFreeFileSetup(setup);
@@ -103,7 +109,7 @@ int main (void)
 		Now open file for reading and ensure that the data read
 		is equal to the data written.
 	*/
-	file = afOpenFile(TEST_FILE, "r", AF_NULL_FILESETUP);
+	file = afOpenFile(sTestFileName, "r", AF_NULL_FILESETUP);
 	ensure(file != NULL, "could not open test file for reading");
 
 	framesread = afReadFrames(file, AF_DEFAULT_TRACK, readbuffer, FRAME_COUNT);

--- a/test/writealaw.c
+++ b/test/writealaw.c
@@ -46,12 +46,15 @@
 #include <audiofile.h>
 #endif
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-#define TEST_FILE "/tmp/test.alaw"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
 
 #define FRAME_COUNT 16
 #define SAMPLE_COUNT FRAME_COUNT
@@ -61,7 +64,7 @@ void testalaw (int fileFormat);
 void cleanup (void)
 {
 #ifndef DEBUG
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 #endif
 }
 
@@ -111,7 +114,9 @@ void testalaw (int fileFormat)
 	afInitFileFormat(setup, fileFormat);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("writealaw", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	afFreeFileSetup(setup);
 
 	ensure(afGetCompression(file, AF_DEFAULT_TRACK) ==
@@ -128,7 +133,7 @@ void testalaw (int fileFormat)
 	afCloseFile(file);
 
 	/* Open the file for reading and verify the data. */
-	file = afOpenFile(TEST_FILE, "r", NULL);
+	file = afOpenFile(sTestFileName, "r", NULL);
 	ensure(file != AF_NULL_FILEHANDLE, "unable to open file for reading");
 
 	ensure(afGetFileFormat(file, NULL) == fileFormat,

--- a/test/writeraw.c
+++ b/test/writeraw.c
@@ -37,17 +37,18 @@
 #include <audiofile.h>
 #endif
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-#define TEST_FILE "/tmp/test.raw"
+static char sTestFileName[PATH_MAX];
 
 void cleanup (void)
 {
 #ifndef DEBUG
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 #endif
 }
 
@@ -82,7 +83,9 @@ int main (int argc, char **argv)
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 	afInitSampleFormat(setup, AF_DEFAULT_TRACK, AF_SAMPFMT_TWOSCOMP, 16);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("writeraw", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	ensure(file != AF_NULL_FILEHANDLE, "unable to open file for writing");
 
 	framesWritten = afWriteFrames(file, AF_DEFAULT_TRACK, samples, 8);
@@ -91,7 +94,7 @@ int main (int argc, char **argv)
 
 	ensure(afCloseFile(file) == 0, "error closing file");
 
-	file = afOpenFile(TEST_FILE, "r", setup);
+	file = afOpenFile(sTestFileName, "r", setup);
 	ensure(file != AF_NULL_FILEHANDLE, "unable to open file for reading");
 	afFreeFileSetup(setup);
 

--- a/test/writeulaw.c
+++ b/test/writeulaw.c
@@ -46,12 +46,15 @@
 #include <audiofile.h>
 #endif
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-#define TEST_FILE "/tmp/test.ulaw"
+#include "TestUtilities.h"
+
+static char sTestFileName[PATH_MAX];
 
 #define FRAME_COUNT 16
 #define SAMPLE_COUNT FRAME_COUNT
@@ -61,7 +64,7 @@ void testulaw (int fileFormat);
 void cleanup (void)
 {
 #ifndef DEBUG
-	unlink(TEST_FILE);
+	unlink(sTestFileName);
 #endif
 }
 
@@ -111,7 +114,9 @@ void testulaw (int fileFormat)
 	afInitFileFormat(setup, fileFormat);
 	afInitChannels(setup, AF_DEFAULT_TRACK, 1);
 
-	file = afOpenFile(TEST_FILE, "w", setup);
+	ensure(createTemporaryFile("writeulaw", sTestFileName),
+		"could not create temporary file");
+	file = afOpenFile(sTestFileName, "w", setup);
 	afFreeFileSetup(setup);
 
 	ensure(afGetCompression(file, AF_DEFAULT_TRACK) ==
@@ -128,7 +133,7 @@ void testulaw (int fileFormat)
 	afCloseFile(file);
 
 	/* Open the file for reading and verify the data. */
-	file = afOpenFile(TEST_FILE, "r", NULL);
+	file = afOpenFile(sTestFileName, "r", NULL);
 	ensure(file != AF_NULL_FILEHANDLE, "unable to open file for reading");
 
 	ensure(afGetFileFormat(file, NULL) == fileFormat,


### PR DESCRIPTION
Use the PKG_INSTALLDIR macro to allow setting where .pc files go
with the --with-pkgconfigdir switch.

	modified:   Makefile.am
	modified:   configure.ac