### PR TITLE
Replace bzero() with memset()

### DIFF
--- a/libaudiofile/CAF.cpp
+++ b/libaudiofile/CAF.cpp
@@ -706,7 +706,7 @@ void CAFFile::initALACCompressionParams()
 	if (track->f.channelCount > 2)
 		codecDataSize += kChannelAtomSize + kALACAudioChannelLayoutSize;
 	m_codecData = new Buffer(codecDataSize);
-	bzero(m_codecData->data(), m_codecData->size());
+	memset(m_codecData->data(), 0, m_codecData->size());
 
 	AUpvlist pv = AUpvnew(2);
 


### PR DESCRIPTION
This fixes the build with MinGW, which doesn't have bzero.

In addition, POSIX mentions that memset() is preferred over bzero() for
portability reasons.