### PR TITLE
source fixes for GCC 6

### DIFF
--- a/libaudiofile/modules/SimpleModule.h
+++ b/libaudiofile/modules/SimpleModule.h
@@ -123,7 +123,7 @@ struct signConverter
 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
 
 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
-	static const int kMinSignedValue = -1 << kScaleBits;
+	static const int kMinSignedValue = 0L-(1<<kScaleBits);
 
 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
 	{

--- a/libaudiofile/modules/SimpleModule.h
+++ b/libaudiofile/modules/SimpleModule.h
@@ -123,7 +123,7 @@ struct signConverter
 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
 
 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
-	static const int kMinSignedValue = 0-(1UL<<kScaleBits);
+	static const int kMinSignedValue = 0-(1U<<kScaleBits);
 
 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
 	{

--- a/libaudiofile/modules/SimpleModule.h
+++ b/libaudiofile/modules/SimpleModule.h
@@ -123,7 +123,7 @@ struct signConverter
 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
 
 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
-	static const int kMinSignedValue = 0L-(1<<kScaleBits);
+	static const int kMinSignedValue = 0-(1UL<<kScaleBits);
 
 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
 	{

--- a/test/FloatToInt.cpp
+++ b/test/FloatToInt.cpp
@@ -115,7 +115,7 @@ TEST_F(FloatToIntTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = -1<<23;
+static const int32_t kMinInt24 = 0L-(1<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 
 TEST_F(FloatToIntTest, Int24)

--- a/test/FloatToInt.cpp
+++ b/test/FloatToInt.cpp
@@ -115,7 +115,7 @@ TEST_F(FloatToIntTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = 0L-(1<<23);
+static const int32_t kMinInt24 = 0-(1UL<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 
 TEST_F(FloatToIntTest, Int24)

--- a/test/FloatToInt.cpp
+++ b/test/FloatToInt.cpp
@@ -115,7 +115,7 @@ TEST_F(FloatToIntTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = 0-(1UL<<23);
+static const int32_t kMinInt24 = 0-(1U<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 
 TEST_F(FloatToIntTest, Int24)

--- a/test/IntToFloat.cpp
+++ b/test/IntToFloat.cpp
@@ -117,7 +117,7 @@ TEST_F(IntToFloatTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = -1<<23;
+static const int32_t kMinInt24 = 0L-(1<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 
 TEST_F(IntToFloatTest, Int24)

--- a/test/IntToFloat.cpp
+++ b/test/IntToFloat.cpp
@@ -117,7 +117,7 @@ TEST_F(IntToFloatTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = 0-(1UL<<23);
+static const int32_t kMinInt24 = 0-(1U<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 
 TEST_F(IntToFloatTest, Int24)

--- a/test/IntToFloat.cpp
+++ b/test/IntToFloat.cpp
@@ -117,7 +117,7 @@ TEST_F(IntToFloatTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = 0L-(1<<23);
+static const int32_t kMinInt24 = 0-(1UL<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 
 TEST_F(IntToFloatTest, Int24)

--- a/test/NeXT.cpp
+++ b/test/NeXT.cpp
@@ -41,9 +41,9 @@ const char kDataUnspecifiedLength[] =
 {
 	'.', 's', 'n', 'd',
 	0, 0, 0, 24, // offset of 24 bytes
-	0xff, 0xff, 0xff, 0xff, // unspecified length
+	-1, -1, -1, -1, // unspecified length
 	0, 0, 0, 3, // 16-bit linear
-	0, 0, 172, 68, // 44100 Hz
+	0, 0, -84, 68, // 44100 Hz (0xAC44)
 	0, 0, 0, 1, // 1 channel
 	0, 1,
 	0, 1,
@@ -63,7 +63,7 @@ const char kDataTruncated[] =
 	0, 0, 0, 24, // offset of 24 bytes
 	0, 0, 0, 20, // length of 20 bytes
 	0, 0, 0, 3, // 16-bit linear
-	0, 0, 172, 68, // 44100 Hz
+	0, 0, -84, 68, // 44100 Hz (0xAC44)
 	0, 0, 0, 1, // 1 channel
 	0, 1,
 	0, 1,
@@ -158,7 +158,7 @@ const char kDataZeroChannels[] =
 	0, 0, 0, 24, // offset of 24 bytes
 	0, 0, 0, 2, // 2 bytes
 	0, 0, 0, 3, // 16-bit linear
-	0, 0, 172, 68, // 44100 Hz
+	0, 0, -84, 68, // 44100 Hz (0xAC44)
 	0, 0, 0, 0, // 0 channels
 	0, 1
 };

--- a/test/NeXT.cpp
+++ b/test/NeXT.cpp
@@ -37,7 +37,7 @@
 
 #include "TestUtilities.h"
 
-const char kDataUnspecifiedLength[] =
+const signed char kDataUnspecifiedLength[] =
 {
 	'.', 's', 'n', 'd',
 	0, 0, 0, 24, // offset of 24 bytes
@@ -57,7 +57,7 @@ const char kDataUnspecifiedLength[] =
 	0, 55
 };
 
-const char kDataTruncated[] =
+const signed char kDataTruncated[] =
 {
 	'.', 's', 'n', 'd',
 	0, 0, 0, 24, // offset of 24 bytes
@@ -152,7 +152,7 @@ TEST(NeXT, Truncated)
 	ASSERT_EQ(::unlink(testFileName.c_str()), 0);
 }
 
-const char kDataZeroChannels[] =
+const signed char kDataZeroChannels[] =
 {
 	'.', 's', 'n', 'd',
 	0, 0, 0, 24, // offset of 24 bytes

--- a/test/Sign.cpp
+++ b/test/Sign.cpp
@@ -116,7 +116,7 @@ TEST_F(SignConversionTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = -1<<23;
+static const int32_t kMinInt24 = 0L-(1<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 static const uint32_t kMaxUInt24 = (1<<24) - 1;
 

--- a/test/Sign.cpp
+++ b/test/Sign.cpp
@@ -116,7 +116,7 @@ TEST_F(SignConversionTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = 0-(1UL<<23);
+static const int32_t kMinInt24 = 0-(1U<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 static const uint32_t kMaxUInt24 = (1<<24) - 1;
 

--- a/test/Sign.cpp
+++ b/test/Sign.cpp
@@ -116,7 +116,7 @@ TEST_F(SignConversionTest, Int16)
 		EXPECT_EQ(readData[i], expectedData[i]);
 }
 
-static const int32_t kMinInt24 = 0L-(1<<23);
+static const int32_t kMinInt24 = 0-(1UL<<23);
 static const int32_t kMaxInt24 = (1<<23) - 1;
 static const uint32_t kMaxUInt24 = (1<<24) - 1;
 


### PR DESCRIPTION
GCC 6 rejects the left shift of a non-positive number in several files and also throws a narrowing-conversion error for the arrays in test/NeXT.cpp
