### PR TITLE
Cast to unsigned while left bit-shifting

### DIFF
--- a/libaudiofile/modules/SimpleModule.h
+++ b/libaudiofile/modules/SimpleModule.h
@@ -123,7 +123,7 @@ struct signConverter
 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
 
 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
-	static const int kMinSignedValue = -1 << kScaleBits;
+	static const int kMinSignedValue = static_cast<signed>(static_cast<unsigned>(-1) << kScaleBits);;
 
 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
 	{


### PR DESCRIPTION
GCC-6 now treats the left bitwise-shift of a negative integer as nonconformant so explicitly cast to an unsigned int while bit-shifting.
