### PR TITLE
Actually fail when an error occurs in parseFormat

### DIFF
--- a/libaudiofile/WAVE.cpp
+++ b/libaudiofile/WAVE.cpp
@@ -326,6 +326,7 @@ status WAVEFile::parseFormat(const Tag &id, uint32_t size)
 			{
 				_af_error(AF_BAD_NOT_IMPLEMENTED,
 					"IMA ADPCM compression supports only 4 bits per sample");
+				return AF_FAIL;
 			}
 
 			int bytesPerBlock = (samplesPerBlock + 14) / 8 * 4 * channelCount;
@@ -333,6 +334,7 @@ status WAVEFile::parseFormat(const Tag &id, uint32_t size)
 			{
 				_af_error(AF_BAD_CODEC_CONFIG,
 					"Invalid samples per block for IMA ADPCM compression");
+				return AF_FAIL;
 			}
 
 			track->f.sampleWidth = 16;

--- a/libaudiofile/modules/BlockCodec.cpp
+++ b/libaudiofile/modules/BlockCodec.cpp
@@ -47,7 +47,7 @@ void BlockCodec::runPull()
 
 	// Read the compressed data.
 	ssize_t bytesRead = read(m_inChunk->buffer, m_bytesPerPacket * blockCount);
-	int blocksRead = bytesRead >= 0 ? bytesRead / m_bytesPerPacket : 0;
+	int blocksRead = (bytesRead >= 0 && m_bytesPerPacket > 0) ? bytesRead / m_bytesPerPacket : 0;
 
 	// Decompress into m_outChunk.
 	for (int i=0; i<blocksRead; i++)


### PR DESCRIPTION
When there's an unsupported number of bits per sample or an invalid
number of samples per block, don't only print an error message using
the error handler, but actually stop parsing the file.

This fixes #35 (also reported at
https://bugzilla.opensuse.org/show_bug.cgi?id=1026983 and
https://blogs.gentoo.org/ago/2017/02/20/audiofile-heap-based-buffer-overflow-in-imadecodeblockwave-ima-cpp/
)