### PR TITLE
Fix static linking with libsndfile

### DIFF
--- a/libaudiofile/alac/ALACEncoder.cpp
+++ b/libaudiofile/alac/ALACEncoder.cpp
@@ -332,19 +332,19 @@ int32_t ALACEncoder::EncodeStereo( BitBuffer * bitstream, void * inputBuffer, ui
         switch ( mBitDepth )
         {
             case 16:
-                mix16( (int16_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate, mixBits, mixRes );
+                audiofile_alac_mix16( (int16_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate, mixBits, mixRes );
                 break;
             case 20:
-                mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate, mixBits, mixRes );
+                audiofile_alac_mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate, mixBits, mixRes );
                 break;
             case 24:
                 // includes extraction of shifted-off bytes
-                mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate,
+                audiofile_alac_mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate,
                         mixBits, mixRes, mShiftBufferUV, bytesShifted );
                 break;
             case 32:
                 // includes extraction of shifted-off bytes
-                mix32( (int32_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate,
+                audiofile_alac_mix32( (int32_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples/dilate,
                         mixBits, mixRes, mShiftBufferUV, bytesShifted );
                 break;
         }
@@ -379,19 +379,19 @@ int32_t ALACEncoder::EncodeStereo( BitBuffer * bitstream, void * inputBuffer, ui
 	switch ( mBitDepth )
 	{
 		case 16:
-			mix16( (int16_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
+			audiofile_alac_mix16( (int16_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
 			break;
 		case 20:
-			mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
+			audiofile_alac_mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
 			break;
 		case 24:
 			// also extracts the shifted off bytes into the shift buffers
-			mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
+			audiofile_alac_mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
 					mixBits, mixRes, mShiftBufferUV, bytesShifted );
 			break;
 		case 32:
 			// also extracts the shifted off bytes into the shift buffers
-			mix32( (int32_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
+			audiofile_alac_mix32( (int32_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
 					mixBits, mixRes, mShiftBufferUV, bytesShifted );
 			break;
 	}
@@ -605,19 +605,19 @@ int32_t ALACEncoder::EncodeStereoFast( BitBuffer * bitstream, void * inputBuffer
 	switch ( mBitDepth )
 	{
 		case 16:
-			mix16( (int16_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
+			audiofile_alac_mix16( (int16_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
 			break;
 		case 20:
-			mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
+			audiofile_alac_mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, mixBits, mixRes );
 			break;
 		case 24:
 			// also extracts the shifted off bytes into the shift buffers
-			mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
+			audiofile_alac_mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
 					mixBits, mixRes, mShiftBufferUV, bytesShifted );
 			break;
 		case 32:
 			// also extracts the shifted off bytes into the shift buffers
-			mix32( (int32_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
+			audiofile_alac_mix32( (int32_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples,
 					mixBits, mixRes, mShiftBufferUV, bytesShifted );
 			break;
 	}
@@ -756,7 +756,7 @@ int32_t ALACEncoder::EncodeStereoEscape( BitBuffer * bitstream, void * inputBuff
 			break;
 		case 20:
 			// mix20() with mixres param = 0 means de-interleave so use it to simplify things
-			mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, 0, 0 );
+			audiofile_alac_mix20( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, 0, 0 );
 			for ( index = 0; index < numSamples; index++ )
 			{
 				BitBufferWrite( bitstream, mMixBufferU[index], 20 );
@@ -765,7 +765,7 @@ int32_t ALACEncoder::EncodeStereoEscape( BitBuffer * bitstream, void * inputBuff
 			break;
 		case 24:
 			// mix24() with mixres param = 0 means de-interleave so use it to simplify things
-			mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, 0, 0, mShiftBufferUV, 0 );
+			audiofile_alac_mix24( (uint8_t *) inputBuffer, stride, mMixBufferU, mMixBufferV, numSamples, 0, 0, mShiftBufferUV, 0 );
 			for ( index = 0; index < numSamples; index++ )
 			{
 				BitBufferWrite( bitstream, mMixBufferU[index], 24 );

--- a/libaudiofile/alac/matrix_enc.c
+++ b/libaudiofile/alac/matrix_enc.c
@@ -57,7 +57,7 @@
 
 // 16-bit routines
 
-void mix16( int16_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres )
+void audiofile_alac_mix16( int16_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres )
 {
 	int16_t	*	ip = in;
 	int32_t			j;
@@ -95,7 +95,7 @@ void mix16( int16_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t num
 // 20-bit routines
 // - the 20 bits of data are left-justified in 3 bytes of storage but right-aligned for input/output predictor buffers
 
-void mix20( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres )
+void audiofile_alac_mix20( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres )
 {
 	int32_t		l, r;
 	uint8_t *	ip = in;
@@ -140,7 +140,7 @@ void mix20( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t num
 // 24-bit routines
 // - the 24 bits of data are right-justified in the input/output predictor buffers
 
-void mix24( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
+void audiofile_alac_mix24( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
 			int32_t mixbits, int32_t mixres, uint16_t * shiftUV, int32_t bytesShifted )
 {	
 	int32_t		l, r;
@@ -240,7 +240,7 @@ void mix24( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t num
 // - otherwise, the calculations might overflow into the 33rd bit and be lost
 // - therefore, these routines deal with the specified "unused lower" bytes in the "shift" buffers
 
-void mix32( int32_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
+void audiofile_alac_mix32( int32_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
 			int32_t mixbits, int32_t mixres, uint16_t * shiftUV, int32_t bytesShifted )
 {
 	int32_t	*	ip = in;

--- a/libaudiofile/alac/matrixlib.h
+++ b/libaudiofile/alac/matrixlib.h
@@ -38,17 +38,17 @@ extern "C" {
 #endif
 
 // 16-bit routines
-void	mix16( int16_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres );
+void	audiofile_alac_mix16( int16_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres );
 void	unmix16( int32_t * u, int32_t * v, int16_t * out, uint32_t stride, int32_t numSamples, int32_t mixbits, int32_t mixres );
 
 // 20-bit routines
-void	mix20( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres );
+void	audiofile_alac_mix20( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples, int32_t mixbits, int32_t mixres );
 void	unmix20( int32_t * u, int32_t * v, uint8_t * out, uint32_t stride, int32_t numSamples, int32_t mixbits, int32_t mixres );
 
 // 24-bit routines
 // - 24-bit data sometimes compresses better by shifting off the bottom byte so these routines deal with
 //	 the specified "unused lower bytes" in the combined "shift" buffer
-void	mix24( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
+void	audiofile_alac_mix24( uint8_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
 				int32_t mixbits, int32_t mixres, uint16_t * shiftUV, int32_t bytesShifted );
 void	unmix24( int32_t * u, int32_t * v, uint8_t * out, uint32_t stride, int32_t numSamples,
 				 int32_t mixbits, int32_t mixres, uint16_t * shiftUV, int32_t bytesShifted );
@@ -57,7 +57,7 @@ void	unmix24( int32_t * u, int32_t * v, uint8_t * out, uint32_t stride, int32_t 
 // - note that these really expect the internal data width to be < 32-bit but the arrays are 32-bit
 // - otherwise, the calculations might overflow into the 33rd bit and be lost
 // - therefore, these routines deal with the specified "unused lower" bytes in the combined "shift" buffer
-void	mix32( int32_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
+void	audiofile_alac_mix32( int32_t * in, uint32_t stride, int32_t * u, int32_t * v, int32_t numSamples,
 				int32_t mixbits, int32_t mixres, uint16_t * shiftUV, int32_t bytesShifted );
 void	unmix32( int32_t * u, int32_t * v, int32_t * out, uint32_t stride, int32_t numSamples,
 				 int32_t mixbits, int32_t mixres, uint16_t * shiftUV, int32_t bytesShifted );


### PR DESCRIPTION
libsndfile and audiofile both contain mixXX functions in their alac
code which lead to symbol name clashes when apps like mpd try to
statically link to both audiofile and libsndfile at the same time.

This patch renames these functions to avoid the problem which was
detected by the buildroot autobuilders:
http://autobuild.buildroot.net/results/799/7997ccd698f03885f98d00bd150dc3a578e4b161/