### PR TITLE
ModuleState: handle compress/decompress init failure

### DIFF
--- a/libaudiofile/modules/ALAC.cpp
+++ b/libaudiofile/modules/ALAC.cpp
@@ -240,6 +240,7 @@ void ALAC::runPull()
 	if (read(m_inChunk->buffer, bytesPerPacket) < bytesPerPacket)
 	{
 		reportReadError(0, m_track->f.framesPerPacket);
+		m_outChunk->frameCount = 0;
 		return;
 	}
 

--- a/libaudiofile/modules/ModuleState.cpp
+++ b/libaudiofile/modules/ModuleState.cpp
@@ -75,6 +75,9 @@ status ModuleState::initFileModule(AFfilehandle file, Track *track)
 		m_fileModule = unit->initcompress(track, file->m_fh, file->m_seekok,
 			file->m_fileFormat == AF_FILE_RAWDATA, &chunkFrames);
 
+	if (!m_fileModule)
+		return AF_FAIL;
+
 	if (unit->needsRebuffer)
 	{
 		assert(unit->nativeSampleFormat == AF_SAMPFMT_TWOSCOMP);

--- a/libaudiofile/modules/SimpleModule.cpp
+++ b/libaudiofile/modules/SimpleModule.cpp
@@ -26,6 +26,7 @@
 void SimpleModule::runPull()
 {
 	pull(m_outChunk->frameCount);
+	m_outChunk->frameCount = m_inChunk->frameCount;
 	run(*m_inChunk, *m_outChunk);
 }
 


### PR DESCRIPTION
When the unit initcompress or initdecompress function fails,
m_fileModule is NULL. Return AF_FAIL in that case instead of
causing NULL pointer dereferences later.

Fixes #49