### PR TITLE
A few small compilation fixes

### DIFF
--- a/libaudiofile/File.cpp
+++ b/libaudiofile/File.cpp
@@ -38,7 +38,9 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <stdio.h>
 
 class FilePOSIX : public File

--- a/libaudiofile/Makefile.am
+++ b/libaudiofile/Makefile.am
@@ -49,8 +49,8 @@ libaudiofile_la_SOURCES = \
 	Tag.h \
 	Track.cpp \
 	Track.h \
-	UUID.cpp \
-	UUID.h \
+	af_UUID.cpp \
+	af_UUID.h \
 	VOC.cpp \
 	VOC.h \
 	WAVE.cpp \

--- a/libaudiofile/WAVE.cpp
+++ b/libaudiofile/WAVE.cpp
@@ -42,7 +42,7 @@
 #include "Setup.h"
 #include "Tag.h"
 #include "Track.h"
-#include "UUID.h"
+#include "af_UUID.h"
 #include "byteorder.h"
 #include "util.h"
 
@@ -127,22 +127,22 @@ static const _AFfilesetup waveDefaultFileSetup =
 	NULL			/* miscellaneous */
 };
 
-static const UUID _af_wave_guid_pcm =
+static const af_UUID _af_wave_guid_pcm =
 {{
 	0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
 	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
 }};
-static const UUID _af_wave_guid_ieee_float =
+static const af_UUID _af_wave_guid_ieee_float =
 {{
 	0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
 	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
 }};
-static const UUID _af_wave_guid_ulaw =
+static const af_UUID _af_wave_guid_ulaw =
 {{
 	0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
 	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
 }};
-static const UUID _af_wave_guid_alaw =
+static const af_UUID _af_wave_guid_alaw =
 {{
 	0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
 	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
@@ -357,7 +357,7 @@ status WAVEFile::parseFormat(const Tag &id, uint32_t size)
 			readU16(&reserved);
 			uint32_t channelMask;
 			readU32(&channelMask);
-			UUID subformat;
+			af_UUID subformat;
 			readUUID(&subformat);
 			if (subformat == _af_wave_guid_pcm)
 			{
@@ -1534,12 +1534,12 @@ status WAVEFile::writeInit(AFfilesetup setup)
 	return AF_SUCCEED;
 }
 
-bool WAVEFile::readUUID(UUID *u)
+bool WAVEFile::readUUID(af_UUID *u)
 {
 	return m_fh->read(u->data, 16) == 16;
 }
 
-bool WAVEFile::writeUUID(const UUID *u)
+bool WAVEFile::writeUUID(const af_UUID *u)
 {
 	return m_fh->write(u->data, 16) == 16;
 }

--- a/libaudiofile/WAVE.h
+++ b/libaudiofile/WAVE.h
@@ -39,7 +39,7 @@ extern const InstParamInfo _af_wave_inst_params[_AF_WAVE_NUM_INSTPARAMS];
 #define _AF_WAVE_NUM_COMPTYPES 4
 extern const int _af_wave_compression_types[_AF_WAVE_NUM_COMPTYPES];
 
-struct UUID;
+struct af_UUID;
 
 class WAVEFile : public _AFfilehandle
 {
@@ -86,8 +86,8 @@ private:
 	status writeCues();
 	status writeData();
 
-	bool readUUID(UUID *g);
-	bool writeUUID(const UUID *g);
+	bool readUUID(af_UUID *g);
+	bool writeUUID(const af_UUID *g);
 
 	bool writeZString(const char *);
 	size_t zStringLength(const char *);

--- a/libaudiofile/af_UUID.cpp
+++ b/libaudiofile/af_UUID.cpp
@@ -28,22 +28,22 @@
 */
 
 #include "config.h"
-#include "UUID.h"
+#include "af_UUID.h"
 
 #include <stdio.h>
 #include <string.h>
 
-bool UUID::operator==(const UUID &u) const
+bool af_UUID::operator==(const af_UUID &u) const
 {
 	return !memcmp(data, u.data, 16);
 }
 
-bool UUID::operator!=(const UUID &u) const
+bool af_UUID::operator!=(const af_UUID &u) const
 {
 	return memcmp(data, u.data, 16) != 0;
 }
 
-std::string UUID::name() const
+std::string af_UUID::name() const
 {
 	char s[37];
 	uint32_t u1 =

--- a/libaudiofile/af_UUID.h
+++ b/libaudiofile/af_UUID.h
@@ -33,12 +33,11 @@
 #include <stdint.h>
 #include <string>
 
-struct UUID
-{
+struct af_UUID {
 	uint8_t data[16];
 
-	bool operator==(const UUID &) const;
-	bool operator!=(const UUID &) const;
+	bool operator==(const af_UUID &) const;
+	bool operator!=(const af_UUID &) const;
 	std::string name() const;
 };
 

--- a/libaudiofile/alac/ALACBitUtilities.h
+++ b/libaudiofile/alac/ALACBitUtilities.h
@@ -54,7 +54,7 @@ enum
 };
     
 
-typedef enum
+enum
 {
     
     ID_SCE = 0,						/* Single Channel Element   */
@@ -65,7 +65,7 @@ typedef enum
     ID_PCE = 5,
     ID_FIL = 6,
     ID_END = 7
-} ELEMENT_TYPE;
+};
 
 // types
 typedef struct BitBuffer

--- a/libaudiofile/modules/BlockCodec.cpp
+++ b/libaudiofile/modules/BlockCodec.cpp
@@ -24,6 +24,7 @@
 #include "Track.h"
 
 #include <assert.h>
+#include <algorithm>
 
 BlockCodec::BlockCodec(Mode mode, Track *track, File *fh, bool canSeek) :
 	FileModule(mode, track, fh, canSeek),


### PR DESCRIPTION
Sorry about the renaming of `UUID` to `af_UUID`, but unfortunately `UUID` is just one of those symbols that is all over the Windows SDK. Renaming it is probably the easiest solution here.