### PR TITLE
Fix -Werror=strict-prototypes

### DIFF
--- a/libaudiofile/g711.c
+++ b/libaudiofile/g711.c
@@ -74,8 +74,7 @@ static int search(int val, const short *table, int size)
  * John Wiley & Sons, pps 98-111 and 472-476.
  */
 unsigned char
-_af_linear2alaw(pcm_val)
-	int		pcm_val;	/* 2's complement (16-bit range) */
+_af_linear2alaw(int pcm_val)		/* 2's complement (16-bit range) */
 {
 	int		mask;
 	int		seg;
@@ -110,8 +109,7 @@ _af_linear2alaw(pcm_val)
  *
  */
 int
-_af_alaw2linear(a_val)
-	unsigned char	a_val;
+_af_alaw2linear(unsigned char a_val)
 {
 	int		t;
 	int		seg;

--- a/sfcommands/sfinfo.c
+++ b/sfcommands/sfinfo.c
@@ -48,7 +48,7 @@ void errorHandler(long error, const char *message)
 		fprintf(stderr, "sfinfo: %s [error %ld]\n", message, error);
 }
 
-void printusage()
+void printusage(void)
 {
 	printf("usage: sfinfo [options...] soundfiles...\n");
 	printf("options:\n");
@@ -58,7 +58,7 @@ void printusage()
 	printf("  -v, --version      Print version\n");
 }
 
-void printversion()
+void printversion(void)
 {
 	printf("sfinfo: Audio File Library version %s\n", VERSION);
 }


### PR DESCRIPTION
This will be required for upcoming gcc and clang versions.

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240