### PR TITLE
fix null pointer dereference in function ModuleState::setup

### DIFF
--- a/libaudiofile/modules/ModuleState.cpp
+++ b/libaudiofile/modules/ModuleState.cpp
@@ -118,6 +118,9 @@ status ModuleState::setup(AFfilehandle file, Track *track)
 		return AF_FAIL;
 	}
 
+	if (!m_fileModule)
+		return AF_FAIL;
+
 	if (arrange(file, track) == AF_FAIL)
 		return AF_FAIL;
 


### PR DESCRIPTION
fix #66: null pointer dereference in function ModuleState::setup